### PR TITLE
meson.build: explicitly depend on threads and nlohmann_json

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,6 +2,9 @@ project('sqlitewriter', 'cpp', default_options : ['cpp_std=c++17'])
 
 sqlitedep = dependency('sqlite3', version : '>3')
 
+threaddep = dependency('threads')
+
+jsondep = dependency('nlohmann_json')
 
 #add_executable(demo demo.cc sqlwriter.cc)
 #target_link_libraries(demo  sqlite3  pthread  dl  )
@@ -12,7 +15,7 @@ sqlitewriter_lib = library(
   'jsonhelper.cc',
   install: false,
   include_directories: '',
-  dependencies: [sqlitedep]
+  dependencies: [sqlitedep, threaddep, jsondep]
 )
 
 sqlitewriter_dep = declare_dependency(
@@ -26,8 +29,8 @@ endif
 
 
 executable('demo', 'demo.cc', 'sqlwriter.cc',  'jsonhelper.cc',
-	dependencies: [sqlitedep])
+	dependencies: [sqlitedep, threaddep, jsondep])
 
 executable('testrunner', 'testrunner.cc', 'sqlwriter.cc',  'jsonhelper.cc',
-	dependencies: [sqlitedep])
+	dependencies: [sqlitedep, threaddep, jsondep])
 


### PR DESCRIPTION
Adding `threads` fixes linking on Debian 11.

Adding `nlohmann_json` moves failure (if absent) from the compile stage to the setup stage.