### PR TITLE
Ensure C-string arguments from string_views are null-terminated

### DIFF
--- a/minipsql.cc
+++ b/minipsql.cc
@@ -6,7 +6,7 @@ using namespace std;
 
 MiniPSQL::MiniPSQL(std::string_view fname)
 {
-  d_conn = PQconnectdb(&fname[0]);
+  d_conn = PQconnectdb(string(fname).c_str());
   if (PQstatus(d_conn) != CONNECTION_OK) {
     throw std::runtime_error("Error connecting to postgresql: "+ string(PQerrorMessage(d_conn)));
   }  

--- a/sqlwriter.cc
+++ b/sqlwriter.cc
@@ -12,7 +12,7 @@ MiniSQLite::MiniSQLite(std::string_view fname, SQLWFlag flag)
   else
     flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE;
   
-  if ( sqlite3_open_v2(&fname[0], &d_sqlite, flags, 0)!=SQLITE_OK) {
+  if (sqlite3_open_v2(string(fname).c_str(), &d_sqlite, flags, 0) != SQLITE_OK) {
     throw runtime_error("Unable to open "+(string)fname+" for sqlite");
   }
   sqlite3_extended_result_codes(d_sqlite, 1);
@@ -55,7 +55,7 @@ vector<vector<string>> MiniSQLite::exec(std::string_view str)
   std::string errstr;
   //  int (*callback)(void*,int,char**,char**)
   d_rows.clear();
-  int rc = sqlite3_exec(d_sqlite, &str[0], helperFunc, this, &errmsg);
+  int rc = sqlite3_exec(d_sqlite, string(str).c_str(), helperFunc, this, &errmsg);
   if (rc != SQLITE_OK) {
     errstr = errmsg;
     sqlite3_free(errmsg);
@@ -96,7 +96,7 @@ void MiniSQLite::prepare(const std::string& table, string_view str)
   }
   const char* pTail;
   
-  if (sqlite3_prepare_v2(d_sqlite, &str[0], -1, &d_stmts[table], &pTail ) != SQLITE_OK) {
+  if (sqlite3_prepare_v2(d_sqlite, str.data(), (int)str.size(), &d_stmts[table], &pTail) != SQLITE_OK) {
     throw runtime_error("Unable to prepare query "+(string)str + ": "+sqlite3_errmsg(d_sqlite));
   }
 }


### PR DESCRIPTION
This requires taking copies; in all cases the strings are relatively short. There is no safe way to check whether string_views are already NULL-terminated.

Fixes #5.