### PR TITLE
Use emplace_back to reduce the number of copies and allocations

### DIFF
--- a/jsonhelper.cc
+++ b/jsonhelper.cc
@@ -6,10 +6,10 @@ using namespace std;
 nlohmann::json packResultsJson(const vector<unordered_map<string, MiniSQLite::outvar_t>>& result, bool fillnull)
 {
   nlohmann::json arr = nlohmann::json::array();
-  
+
   for(const auto& row : result) {
-    nlohmann::json j;
-    for(auto& col : row) {
+    nlohmann::json &j = arr.emplace_back();
+    for(const auto& col : row) {
       std::visit([&j, &col, &fillnull](auto&& arg) {
         using T = std::decay_t<decltype(arg)>;
         if constexpr (std::is_same_v<T, nullptr_t>) {
@@ -23,7 +23,6 @@ nlohmann::json packResultsJson(const vector<unordered_map<string, MiniSQLite::ou
         }
       }, col.second);
     }
-    arr += j;
   }
   return arr;
 }


### PR DESCRIPTION
Converting from SQLite's internal representation to the vector-of-maps representation to the `nlohmann::json` representation will always involve some copying, but this reduces that somewhat by replacing `push_back` and `+=` with `emplace`.

Measuring `packResultsJsonStr` with Valgrind on an example database (22MB) and query (mostly small-ish blobs), this gives:

Before:

    198,962 allocs, 198,962 frees, 350,745,047 bytes allocated

After:

    84,407 allocs, 84,407 frees, 105,728,530 bytes allocated

