### PR TITLE
Swallow commit() exception in MiniSQLite destructor, improve state check

### DIFF
--- a/sqlwriter.hh
+++ b/sqlwriter.hh
@@ -55,7 +55,7 @@ private:
   std::unordered_map<std::string, sqlite3_stmt*> d_stmts;
   std::vector<std::vector<std::string>> d_rows; // for exec()
   static int helperFunc(void* ptr, int cols, char** colvals, char** colnames);
-  bool d_intransaction{false};
+  bool inTransaction();
   bool haveTable(const std::string& table);
 };
 


### PR DESCRIPTION
This makes it so that MiniSQLite's destructor only attempts to commit if a transaction is actually active, and also makes it so that a failure to commit in the destructor is quietly ignored with no exception thrown.

Before, MiniSQLite carried a boolean flag to indicate whether the SQLite database being wrapped was in a transaction, but this flag could diverge from the actual state by...

- the "begin" query or "commit" query failing
- calling code mistakenly doing exec("rollback") or exec("commit")
- automatic rollbacks caused by e.g. disk I/O or disk full errors

In the last case, the error would cause an exception to be thrown, which would trigger stack unwinding, destroying the MiniSQLite. The MiniSQLite destructor, not having noticed the autorollback, would attempt a commit, which would throw another exception, finally reaching std::terminate.

Also adds tests.