### PR TITLE
Replace SQLiteWriter d_columns with metadata call

### DIFF
--- a/sqlwriter.hh
+++ b/sqlwriter.hh
@@ -49,6 +49,8 @@ public:
     else
       return iter->second != nullptr;
   }
+  bool haveTable(const std::string& table);
+  bool haveColumn(const std::string& table, const std::string &column);
 
 private:
   sqlite3* d_sqlite;
@@ -56,7 +58,6 @@ private:
   std::vector<std::vector<std::string>> d_rows; // for exec()
   static int helperFunc(void* ptr, int cols, char** colvals, char** colnames);
   bool d_intransaction{false};
-  bool haveTable(const std::string& table);
 };
 
 class SQLiteWriter
@@ -115,7 +116,6 @@ private:
   std::mutex d_mutex;  
   MiniSQLite d_db;
   SQLWFlag d_flag{SQLWFlag::NoFlag};
-  std::unordered_map<std::string, std::vector<std::pair<std::string, std::string>>> d_columns;
   std::unordered_map<std::string, std::vector<std::string>> d_lastsig;
   std::unordered_map<std::string, bool> d_lastreplace;
   std::map<std::string, std::map<std::string, std::string>> d_meta;

--- a/testrunner.cc
+++ b/testrunner.cc
@@ -158,6 +158,60 @@ TEST_CASE("test queries typed") {
   unlink("testrunner-example.sqlite3");
 }
 
+TEST_CASE("test multiple") {
+  unlink("testrunner-luke.sqlite3");
+
+  {
+    SQLiteWriter a("testrunner-luke.sqlite3");
+    SQLiteWriter b("testrunner-luke.sqlite3");
+
+    a.addValue({{"dalton", "joe"}});
+    b.addValue({{"dalton", "william"}});
+    a.addValue({{"dalton", "jack"}});
+    b.addValue({{"dalton", "averell"}});
+  }
+
+  unlink("testrunner-luke.sqlite3");
+}
+
+TEST_CASE("test column name case") {
+  unlink("testrunner-tintin.sqlite3");
+
+  {
+    SQLiteWriter sqw("testrunner-tintin.sqlite3");
+
+    sqw.addValue({{"name", "tintin"}});
+    sqw.addValue({{"Name", "Snowy"}});
+    sqw.addValue({{"NAME", "CAPTAIN HADDOCK"}});
+  }
+
+  {
+    SQLiteWriter sqw("testrunner-tintin.sqlite3");
+
+    auto res = sqw.query("select name from data order by rowid");
+    CHECK(res.size() == 3);
+    CHECK(res.at(0).at("name") == "tintin");
+    CHECK(res.at(1).at("name") == "Snowy");
+    CHECK(res.at(2).at("name") == "CAPTAIN HADDOCK");
+  }
+
+  unlink("testrunner-tintin.sqlite3");
+}
+
+TEST_CASE("test table name case") {
+  unlink("testrunner-ao.sqlite3");
+
+  {
+    SQLiteWriter sqw("testrunner-ao.sqlite3");
+
+    sqw.addValue({{"name", "Asterix"}}, "a");
+    sqw.addValue({{"name", "Obelix"}}, "a");
+    sqw.addValue({{"name", "Getafix"}}, "A");
+    sqw.addValue({{"name", "Vitalstatistix"}}, "A");
+  }
+
+  unlink("testrunner-ao.sqlite3");
+}
 
 TEST_CASE("test meta") {
   unlink("testrunner-example.sqlite3");


### PR DESCRIPTION
The d_columns field is removed. Instead, to find out whether some column or table exists, the sqlite3_table_column_metadata function is called.

This resolves an issue where multiple connections are open to the SQLite database and calls to addValue cause columns to be added to a table that is also used by others. Before, these new columns would only be added to the d_columns list of the connection that created them, meaning that all others would be out of sync, and stay that way. If they added a row that had the new column, they would attempt an ALTER TABLE, which would fail.

This change also means that we automatically follow SQLite when it comes to case sensitivity, so this should also fix #9.

Finally, the code is slightly simpler.

The getSchema method on MiniSQLite is now unused by the code itself, but since the method is public it is kept in case it is used by API users.