### PR TITLE
Replace SQLiteWriter mutex with SQLite mutex

### DIFF
--- a/sqlwriter.hh
+++ b/sqlwriter.hh
@@ -3,7 +3,6 @@
 #include <vector>
 #include <unordered_map>
 #include <variant>
-#include <mutex>
 #include <thread>
 #include <iostream>
 #include <map>
@@ -49,6 +48,13 @@ public:
     else
       return iter->second != nullptr;
   }
+
+  struct lock_guard {
+    lock_guard(MiniSQLite&);
+    ~lock_guard();
+  private:
+    MiniSQLite& d_target;
+  };
 
 private:
   sqlite3* d_sqlite;
@@ -112,7 +118,6 @@ private:
   void commitThread();
   bool d_pleasequit{false};
   std::optional<std::thread> d_thread;
-  std::mutex d_mutex;  
   MiniSQLite d_db;
   SQLWFlag d_flag{SQLWFlag::NoFlag};
   std::unordered_map<std::string, std::vector<std::pair<std::string, std::string>>> d_columns;


### PR DESCRIPTION
The SQLiteWriter commit thread and the user's main thread share the same connection to the underlying database. The threads are synchronized with a std::mutex on SQLiteWriter.

However, the SQLite connection already carries its own (recursive) mutex which we can use instead. This simplifies the design slightly: there can no longer be a situation where a thread grabs the SQLiteWriter-side lock but has to wait for the SQLite-side lock, which would be very confusing.

This will not work in builds of SQLite with non-defualt threading modes, but in such cases sharing a connection among threads is unsafe anyway.